### PR TITLE
Couchbase 7.1+ compatibility improvement for cluster join operations

### DIFF
--- a/couchbase_cluster_admin/cluster.py
+++ b/couchbase_cluster_admin/cluster.py
@@ -206,10 +206,10 @@ class Cluster(BaseClient):
         )
 
         if resp.status_code == 400:
-            if "Adding nodes to not provisioned" in resp.content:
+            if "Adding nodes to not provisioned" in resp.text:
                 raise AddToNotProvisionedNodeException(resp.text)
 
-            if "Failed to connect to" in resp.content:
+            if "Failed to connect to" in resp.text:
                 raise ConnectToControllerOnJoinException(resp.text)
 
         if resp.status_code != 200:

--- a/couchbase_cluster_admin/cluster.py
+++ b/couchbase_cluster_admin/cluster.py
@@ -1,7 +1,10 @@
+import logging
+
 from .client import BaseClient
 
 COUCHBASE_HOST = "127.0.0.1"
 COUCHBASE_PORT_REST = "8091"
+COUCHBASE_SECURE_PORT_REST = "18091"
 
 
 service_name_memory_quota_table = {
@@ -178,7 +181,7 @@ class Cluster(BaseClient):
     def join_cluster(
         self,
         target_ip,
-        target_port=COUCHBASE_PORT_REST,
+        target_port=COUCHBASE_SECURE_PORT_REST,
         username=None,
         password=None,
         insecure=False,
@@ -190,8 +193,11 @@ class Cluster(BaseClient):
 
         url = f"{self.baseurl}/node/controller/doJoinCluster"
 
+        # In 7.1+, cluster join is only allowed over secure https connections
+        # https://docs.couchbase.com/server/7.1/rest-api/rest-cluster-addnodes.html
         if insecure:
             target_ip = f"http://{target_ip}"
+            logging.warning("Insecure join will be rejected by Couchbase >= 7.1")
 
         resp = self.http_request(
             url,

--- a/couchbase_cluster_admin/cluster.py
+++ b/couchbase_cluster_admin/cluster.py
@@ -92,10 +92,6 @@ class Cluster(BaseClient):
                     raise IllegalArgumentError("total_memory_mb is required for ratios")
                 quotas[quota_name] = int(value * total_memory_mb)
 
-        # The cluster name is also set using this endpoint, but it's not
-        # documented. Found by tracing the web UI.
-        quotas["clusterName"] = self.cluster_name
-
         resp = self.http_request(
             url,
             method="POST",

--- a/couchbase_cluster_admin/cluster.py
+++ b/couchbase_cluster_admin/cluster.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from .client import BaseClient
 
@@ -305,6 +306,17 @@ class Cluster(BaseClient):
 
     def rebalance_is_done(self) -> bool:
         return self.rebalance_progress["status"] == "none"
+
+    def wait_for_rebalance(self, max_wait=60, interval=1):
+        """
+        Waits for a rebalance operation to complete
+        """
+        for _ in range(max_wait):
+            if self.rebalance_is_done():
+                break
+            time.sleep(interval)
+        else:
+            raise TimeoutError("Rebalance did not complete in time.")
 
     @property
     def buckets(self):

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -42,7 +42,6 @@ def test_set_memory_quotas():
         match=[
             matchers.urlencoded_params_matcher(
                 {
-                    "clusterName": "mycluster",
                     "service1": "100",
                     "service2": "200",
                 }
@@ -71,7 +70,6 @@ def test_set_memory_quotas_ratios():
         match=[
             matchers.urlencoded_params_matcher(
                 {
-                    "clusterName": "mycluster",
                     "service1": "10",
                     "service2": "20",
                 }
@@ -139,7 +137,6 @@ def test_set_memory_quotas_by_service_name():
         match=[
             matchers.urlencoded_params_matcher(
                 {
-                    "clusterName": "mycluster",
                     "memoryQuota": "100",
                     "indexMemoryQuota": "200",
                 }


### PR DESCRIPTION
Changed the join cluster operation to default to secure connections on port 18091 rather than 8091.
    
From Couchbase 7.1 onward, joining a cluster is rejected when using the non-secure http port. From the Couchbase documentation:
     
> In consequence, a server to be added can be prefixed with the scheme https://, and/or can be suffixed with the port 18091): if no scheme or port is specified, https:// and 18091 are used as defaults. The scheme http:// cannot be used; nor can the port 8091, since in 7.1+, addition takes place only over a secure connection.
    
See: https://docs.couchbase.com/server/7.1/rest-api/rest-cluster-addnodes.html

I've added a few more changes that seemed generally positive, but I leave that up to you.