### PR TITLE
Retry client requests on read timeout exceptions

### DIFF
--- a/couchbase_cluster_admin/client.py
+++ b/couchbase_cluster_admin/client.py
@@ -1,18 +1,34 @@
+import time
+
 import requests
 
 
 class BaseClient:
-
     def http_request(self, url, method="GET", data=None, headers={}, timeout=10.0):
         auth = None
         if self.username is not None and self.password is not None:
             auth = (self.username, self.password)
 
-        return requests.request(
-            method,
-            url,
-            data=data,
-            headers=headers,
-            auth=auth,
-            timeout=timeout,
-        )
+        # Retrying POST requests could lead to unexpected results,
+        # but we've seen the join cluster operation (a POST) fail most often.
+        max_retries = 3
+
+        while max_retries > 0:
+            try:
+                max_retries = max_retries - 1
+                response = requests.request(
+                    method,
+                    url,
+                    data=data,
+                    headers=headers,
+                    auth=auth,
+                    timeout=timeout,
+                )
+
+                return response
+            except requests.exceptions.ReadTimeout as e:
+                logging.warning(
+                    f"ReadTimeout exception for request {method} {url}. {max_retries} retries left",
+                    e,
+                )
+                time.sleep(1)


### PR DESCRIPTION
Sometimes (rarely) the join cluster operation fails with a `requests.exceptions.ReadTimeout` exception. Our default timeout is 10 seconds, which should be ample enough, but let's have a default number of retries (3) in such cases, to make the library more resilient to temporary timeouts.