### PR TITLE
Added `Cluster.rename_node()`

### DIFF
--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -231,6 +231,31 @@ def test_set_disk_paths():
 
 
 @responses.activate
+def test_rename_node():
+    host = "127.0.0.1"
+    port = "8091"
+
+    responses.add(
+        responses.POST,
+        f"http://{host}:{port}/node/controller/rename",
+        body="",
+        match=[matchers.urlencoded_params_matcher(
+            {
+                "hostname": "newHostname"
+            }
+        )],
+        status=200,
+    )
+
+    c = cluster.Cluster(
+        "mycluster", services=["service1"], api_host=host, api_port=port
+    )
+    c.rename_node("newHostname")
+
+    assert len(responses.calls) == 1
+
+
+@responses.activate
 def test_join_cluster():
     host = "127.0.0.1"
     port = "8091"


### PR DESCRIPTION
In certain scenarios it's useful to be able to rename cluster nodes using f.ex. ec2 public dns names, to be able to use internal IPs for internal cluster communication, and external IPs when the node names are seen from the outside, like in the case of a `cbbackupmgr restore`, where `cbbackupmgr` tries to initiate communication with the internal IP if the nodes are named as such.