### PR TITLE
Added support for configuring backup service threads.

### DIFF
--- a/couchbase_cluster_admin/cluster.py
+++ b/couchbase_cluster_admin/cluster.py
@@ -935,3 +935,19 @@ class Cluster(BaseClient):
             raise Exception(f"Failed to execute query: {resp.text}")
 
         return resp.json()
+
+    def set_backup_service_threads(self, nodes_threads_map: dict):
+        """
+        https://docs.couchbase.com/server/current/rest-api/backup-node-threads.html
+        """
+
+        url = f"{self.baseurl}/_p/backup/api/v1/nodesThreadsMap"
+
+        resp = self.http_request(
+            url,
+            method="POST",
+            json=nodes_threads_map,
+        )
+
+        if resp.status_code != 200:
+            raise Exception(f"Failed to set backup service threads: {resp.text}")


### PR DESCRIPTION
By default the backup service uses `max(1,cpu_cores×0.75)` number of threads. It is now possible to manually change the number of threads being used through the backup REST API.